### PR TITLE
Fixed trailing 0 and trailing . removal

### DIFF
--- a/engineering_notation/engineering_notation.py
+++ b/engineering_notation/engineering_notation.py
@@ -330,8 +330,10 @@ class EngNumber:
         base, exponent = num_str.split('e')
 
         base = str(round(Decimal(base), self.precision))
-        if '.00' in base:
-            base = base[:-3]
+        
+        # remove trailing zeros and decimals:
+        while base[-1] in ".0":
+            base = base[:-1]
 
         return base + _exponent_lookup_scaled[exponent]
 


### PR DESCRIPTION
Fixed trailing 0 and trailing . removal

This obviously breaks the tests. I think it's an improvement. I needed this to be able to match the formatting of a electronic parts database I'm using.

If you don't like this change as is, I could turn it into optional behavior. The existing '.00' trimming is inconsistent with the behavior of .000 and .0 and just . when they occur.