### PR TITLE
Added proper NotImplemented support to __eq__ functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@ __pycache__/
 build/
 dist/
 venv/
+.mypy_cache
+.venv
+conftest.py
+.pytest_cache
+.vscode
+setup.cfg
+.coverage

--- a/engineering_notation/engineering_notation.py
+++ b/engineering_notation/engineering_notation.py
@@ -259,6 +259,8 @@ class EngUnit:
         :param other: EngNum, float, or int
         :return: result
         """
+        if not isinstance(other, (EngNumber, EngUnit, str, int, float)):
+            return NotImplemented
         if not isinstance(other, EngNumber):
             other = EngUnit(str(other))
 
@@ -525,6 +527,8 @@ class EngNumber:
         :param other: EngNum, float, or int
         :return: result
         """
+        if not isinstance(other, (EngNumber, str, int, float)):
+            return NotImplemented
         if not isinstance(other, EngNumber):
             other = EngNumber(other)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -182,6 +182,9 @@ def test_enum_eq():
     assert -220000 == EngNumber('-220k')
     assert -220000.0 == EngNumber('-220k')
 
+    assert not (EngNumber('220k') == object)
+
+
 
 def test_enum_gt():
     # positive_numbers
@@ -455,6 +458,7 @@ def test_eq():
         EngUnit('220mHz') == 10
     with pytest.raises(AttributeError):
         EngUnit('220mHz') == 10.0
+    assert not (EngUnit('220k') == object)
 
     # negative_numbers
     assert EngUnit('-220k') == EngUnit(-220000)
@@ -469,7 +473,7 @@ def test_eq():
     with pytest.raises(AttributeError):
         EngUnit('-220mHz') == -10
     with pytest.raises(AttributeError):
-       EngUnit('-220mHz') == -10.0
+        EngUnit('-220mHz') == -10.0
 
 
 def test_gt():


### PR DESCRIPTION
I learned about this library over the summer and it was very helpful for a project I was working on. However, I had a couple of minor complaints about it. 
During the course of fixing those, my linters identified a few other issues with the package, one of which was that the __eq__ method for both classes was not properly handling unsupported classes, so I added support for that, as well as an additional test case for the __eq__ methods to keep coverage at 100%
Finally, I added stuff to gitignore for Visual Studio Code, and the python utilities I used. 

Note that I made a number of different changes, I have broken them apart by categories in a few different pull requests to simplify decision making on which features should be added.