### PR TITLE
Fix a subtle bracket bug in the unit tests

### DIFF
--- a/tests/test_engnum.py
+++ b/tests/test_engnum.py
@@ -302,12 +302,12 @@ def test_enum_to_enum():
 
 def test_to_str():
     # positive_numbers
-    assert str(EngUnit('220') == '220')
-    assert str(EngUnit('220ohm') == '220ohm')
+    assert str(EngUnit('220')) == '220'
+    assert str(EngUnit('220ohm')) == '220ohm'
 
     # negative_numbers
-    assert str(EngUnit('-220') == '-220')
-    assert str(EngUnit('-220ohm') == '-220ohm')
+    assert str(EngUnit('-220')) == '-220'
+    assert str(EngUnit('-220ohm')) == '-220ohm'
 
     assert EngUnit('220ohm').unit == 'ohm'
     assert EngUnit('220', unit='ohm').unit == 'ohm'


### PR DESCRIPTION
I noticed this while working on adding the separator feature. It's a sneaky one because it would have always passed, so you wouldn't have noticed it unless you were deliberately trying to provoke a failure.