### PR TITLE
Add ability to use separator to EngNumber

### DIFF
--- a/engineering_notation/engineering_notation.py
+++ b/engineering_notation/engineering_notation.py
@@ -45,7 +45,7 @@ class EngUnit:
     Represents an engineering number, complete with units
     """
     def __init__(self, value,
-                 precision=2, significant=0, unit: str = None):
+                 precision=2, significant=0, unit: str = None, separator=""):
         """
         Initialize engineering with units
         :param value: the desired value in the form of a string, int, or float
@@ -70,10 +70,10 @@ class EngUnit:
             if self.unit is None and len(value) >= v_index:
                 self.unit = value[v_index:]
 
-            self.eng_num = EngNumber(new_value, precision, significant)
+            self.eng_num = EngNumber(new_value, precision, significant, separator)
 
         else:
-            self.eng_num = EngNumber(value, precision, significant)
+            self.eng_num = EngNumber(value, precision, significant, separator)
 
     def __repr__(self):
         """
@@ -282,7 +282,7 @@ class EngNumber:
     """
 
     def __init__(self, value,
-                 precision=2, significant=0):
+                 precision=2, significant=0, separator=""):
         """
         Initialize the class
 
@@ -294,6 +294,7 @@ class EngNumber:
         """
         self.precision = precision
         self.significant = significant
+        self.separator = separator
 
         if isinstance(value, str):
             suffix_keys = [key for key in _suffix_lookup.keys() if key != '']
@@ -332,7 +333,7 @@ class EngNumber:
             return string
 
         letter = string[-1]
-        return string.replace('.', letter)[:-1]
+        return string.replace('.', letter)[:-1].strip(self.separator)
 
     def __repr__(self):
         """
@@ -375,7 +376,7 @@ class EngNumber:
             if '.00' in base:
                 base = base[:-3]
 
-        return base + _exponent_lookup_scaled[exponent]
+        return base + self.separator + _exponent_lookup_scaled[exponent]
 
     def __str__(self, eng=True, context=None):
         """

--- a/tests/test_engnum.py
+++ b/tests/test_engnum.py
@@ -70,6 +70,11 @@ def test_engnum_significant():
     assert str(EngNumber('2.22m', significant=3)) == '2.22m'
 
 
+def test_engnum_separator():
+    assert str(EngNumber("1.23k", separator=" ")) == "1.23 k"
+    assert str(EngNumber("1.23k", separator=" ").to_pn()) == "1k23"
+
+
 def test_new_units():
     """
     any new units - such as femto, atto, zepto, etc. should have
@@ -304,10 +309,12 @@ def test_to_str():
     # positive_numbers
     assert str(EngUnit('220') == '220')
     assert str(EngUnit('220ohm') == '220ohm')
+    assert str(EngUnit('220ohm', separator=" ")) == '220 ohm'
 
     # negative_numbers
     assert str(EngUnit('-220') == '-220')
     assert str(EngUnit('-220ohm') == '-220ohm')
+    assert str(EngUnit('-220ohm', separator=" ")) == '-220 ohm'
 
     assert EngUnit('220ohm').unit == 'ohm'
     assert EngUnit('220', unit='ohm').unit == 'ohm'


### PR DESCRIPTION
This now gives the user the opportunity to use a separator between the number part and the magnitude suffix, so I could write `1.2 k` for instance, if I passed a space as a separator.

The default is an empty string, so users not using this feature will be unaffected by this change.

I also added the facility to EngUnit, which calls EngNumber in the implementation.

Closes #23 and possibly #2?