### PR TITLE
Enable mypy type-checking

### DIFF
--- a/engineering_notation/engineering_notation.py
+++ b/engineering_notation/engineering_notation.py
@@ -2,6 +2,8 @@ from decimal import Decimal
 from string import digits
 import sys
 
+from typing import Optional
+
 try:
     import numpy
 except ImportError:
@@ -51,7 +53,7 @@ class EngUnit:
     Represents an engineering number, complete with units
     """
     def __init__(self, value,
-                 precision=2, significant=0, unit: str = None, separator=""):
+                 precision=2, significant=0, unit: Optional[str] = None, separator=""):
         """
         Initialize engineering with units
         :param value: the desired value in the form of a string, int, or float

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from setuptools import setup, find_packages
+from setuptools import setup
+
 import os
 
 __version__ = None
@@ -36,7 +37,8 @@ setup(
     author='Jason R. Jones',
     author_email='slightlynybbled@gmail.com',
     url='https://github.com/slightlynybbled/engineering_notation',
-    packages=find_packages(),
+    packages=["engineering_notation"],
+    package_data={"engineering_notation": ["py.typed"]},
     install_requires=requirements,
     setup_requires=['flake8', 'pytest'],
     license='MIT',


### PR DESCRIPTION
Using the module I was getting this message from mypy:
```
Skipping analyzing "engineering_notation": module is installed, but missing library stubs or py.typed marker
```

While not the biggest issue, I tried my hand at fixing things. This commit represents that attempt. Feedback / criticism welcome.

I also fix a mypy warning about an implicit optional being used.